### PR TITLE
chore: add appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,25 @@
+environment:
+  matrix:
+    - nodejs_version: '8'
+    - nodejs_version: '7'
+    - nodejs_version: '6'
+
+version: '{build}'
+
+# Install scripts. (runs after repo cloning)
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm -g install npm@latest
+  - set PATH=%APPDATA%\npm;%PATH%
+  - node --version
+  - npm --version
+  - npm install
+
+matrix:
+  fast_finish: true
+
+# No need for MSBuild on this project
+build: off
+
+test_script:
+  - npm test


### PR DESCRIPTION
This adds appveyor for Windows test coverage. As per issue #7, we expect
some Windows failures at this point. The intent is to land this first to
track Windows compatibility.

Issue #7