### PR TITLE
test: add shx to test cross-platform binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "nyc": "^6.6.1",
     "shelljs-changelog": "^0.2.0",
     "shelljs-release": "^0.2.0",
-    "should": "^9.0.2"
+    "should": "^9.0.2",
+    "shx": "^0.2.2"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -19,13 +19,7 @@ function unix() {
 }
 
 describe('proxy', () => {
-  let delVarName;
   before(() => {
-    // Configure shell variables so that we can use basic commands for testing
-    // without using the ShellJS builtin
-    shell.env.del = unix() ? 'rm' : 'del';
-    delVarName = unix() ? '$del' : '%del%';
-    shell.env.output = 'echo';
     shell.config.silent = true;
   });
 
@@ -196,7 +190,7 @@ describe('proxy', () => {
     it('handles ShellStrings as arguments', (done) => {
       shell.touch('file.txt');
       fs.existsSync('file.txt').should.equal(true);
-      shell[delVarName](shell.ShellString('file.txt'));
+      shell.shx['--noglob'].rm(shell.ShellString('file.txt'));
       // TODO(nfischer): this fails on Windows
       fs.existsSync('file.txt').should.equal(false);
       done();
@@ -223,8 +217,7 @@ describe('proxy', () => {
     });
 
     it('runs very long subcommand chains', (done) => {
-      const fun = (unix() ? shell.$output : shell['%output%']);
-      const ret = fun.one.two.three.four.five.six('seven');
+      const ret = shell.shx['--noglob'].echo.one.two.three.four.five.six('seven');
       // Note: newline should be '\n', because we're checking a JS string, not
       // something from the file system.
       ret.stdout.should.equal('one two three four five six seven\n');
@@ -243,7 +236,7 @@ describe('proxy', () => {
       shell.exec('echo hello world').to(fb);
       shell.exec('echo hello world').to(fname);
 
-      shell[delVarName](fname);
+      shell.shx['--noglob'].rm(fname);
       // TODO(nfischer): this line fails on Windows
       fs.existsSync(fname).should.equal(false);
       shell.cat(fa).toString().should.equal(`hello world${os.EOL}`);
@@ -260,7 +253,7 @@ describe('proxy', () => {
       shell.exec('echo hello world').to(fa);
       shell.exec('echo hello world').to(fglob);
 
-      shell[delVarName](fglob);
+      shell.shx['--noglob'].rm(fglob);
       // TODO(nfischer): this line fails on Windows
       fs.existsSync(fglob).should.equal(false);
       shell.cat(fa).toString().should.equal(`hello world${os.EOL}`);
@@ -275,7 +268,7 @@ describe('proxy', () => {
         const fquote = 'thisHas"Quotes.txt';
         shell.exec('echo hello world').to(fquote);
         fs.existsSync(fquote).should.equal(true);
-        shell[delVarName](fquote);
+        shell.shx['--noglob'].rm(fquote);
         fs.existsSync(fquote).should.equal(false);
         done();
       } else {

--- a/test/test.js
+++ b/test/test.js
@@ -217,7 +217,7 @@ describe('proxy', () => {
     });
 
     it('runs very long subcommand chains', (done) => {
-      const ret = shell.shx['--noglob'].echo.one.two.three.four.five.six('seven');
+      const ret = shell.shx.echo.one.two.three.four.five.six('seven');
       // Note: newline should be '\n', because we're checking a JS string, not
       // something from the file system.
       ret.stdout.should.equal('one two three four five six seven\n');

--- a/test/test.js
+++ b/test/test.js
@@ -241,13 +241,14 @@ describe('proxy', () => {
       fs.existsSync(fname).should.equal(true);
 
       shell.shx['--noglob'].rm(fname);
-      // TODO(nfischer): this line (still) fails on Windows
-      fs.existsSync(fname).should.equal(false);
       shell.cat(fa).toString().should.equal(`hello world${os.EOL}`);
 
       // These files are still ok
       fs.existsSync(fa).should.equal(true);
       fs.existsSync(fb).should.equal(true);
+
+      // TODO(nfischer): this line (still) fails on Windows
+      fs.existsSync(fname).should.equal(false);
       done();
     }).timeout(5000);
 

--- a/test/test.js
+++ b/test/test.js
@@ -191,7 +191,7 @@ describe('proxy', () => {
       shell.touch('file.txt');
       fs.existsSync('file.txt').should.equal(true);
       shell.shx['--noglob'].rm(shell.ShellString('file.txt'));
-      // TODO(nfischer): this fails on Windows
+      // TODO(nfischer): this line (still) fails on Windows
       fs.existsSync('file.txt').should.equal(false);
       done();
     });
@@ -217,6 +217,7 @@ describe('proxy', () => {
     });
 
     it('runs very long subcommand chains', (done) => {
+      // TODO(nfischer): this returns empty string on Windows
       const ret = shell.shx.echo.one.two.three.four.five.six('seven');
       // Note: newline should be '\n', because we're checking a JS string, not
       // something from the file system.
@@ -235,9 +236,12 @@ describe('proxy', () => {
       shell.exec('echo hello world').to(fa);
       shell.exec('echo hello world').to(fb);
       shell.exec('echo hello world').to(fname);
+      fs.existsSync(fa).should.equal(true);
+      fs.existsSync(fb).should.equal(true);
+      fs.existsSync(fname).should.equal(true);
 
       shell.shx['--noglob'].rm(fname);
-      // TODO(nfischer): this line fails on Windows
+      // TODO(nfischer): this line (still) fails on Windows
       fs.existsSync(fname).should.equal(false);
       shell.cat(fa).toString().should.equal(`hello world${os.EOL}`);
 
@@ -254,7 +258,6 @@ describe('proxy', () => {
       shell.exec('echo hello world').to(fglob);
 
       shell.shx['--noglob'].rm(fglob);
-      // TODO(nfischer): this line fails on Windows
       fs.existsSync(fglob).should.equal(false);
       shell.cat(fa).toString().should.equal(`hello world${os.EOL}`);
 


### PR DESCRIPTION
This adds `shx` as a devdependency to test executing commands across
multiple platforms.

This also passes --noglob to avoid glob expansion from the shelljs
within shx, so that we can accurately test if we avoid the glob
expansion introduced from running shell.exec().

Issue #7