### PR TITLE
test: increase timeouts for flaky tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -277,12 +277,12 @@ describe('proxy', () => {
         fs.existsSync(fquote).should.equal(true);
         shell[delVarName](fquote);
         fs.existsSync(fquote).should.equal(false);
-        done();
       } else {
         // Windows doesn't support `"` as a character in a filename, see
         // https://msdn.microsoft.com/en-us/library/windows/desktop/aa365247(v=vs.85).aspx
         console.log('skipping test');
       }
+      done();
     });
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -252,7 +252,7 @@ describe('proxy', () => {
       fs.existsSync(fa).should.equal(true);
       fs.existsSync(fb).should.equal(true);
       done();
-    });
+    }).timeout(5000);
 
     it('avoids globs', (done) => {
       const fa = 'a.txt';
@@ -268,7 +268,7 @@ describe('proxy', () => {
       // These files are still ok
       fs.existsSync(fa).should.equal(true);
       done();
-    });
+    }).timeout(5000);
 
     it('escapes quotes', (done) => {
       if (unix()) {


### PR DESCRIPTION
This increases timeouts for the 2 flaky tests.

This also fixes a timeout issue for the "escapes quotes" test on Windows, since
we only invoked the `done()` callback from the unix code branch (a bug in #11).

Fixes #14