### PR TITLE
chore: update shelljs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: node_js
 sudo: false
 node_js:
   - 6
-  - 7
   - 8
+  - 10
+  - 12
+  - 14
 
 os:
   - linux

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,9 @@
 environment:
   matrix:
+    - nodejs_version: '14'
+    - nodejs_version: '12'
+    - nodejs_version: '10'
     - nodejs_version: '8'
-    - nodejs_version: '7'
     - nodejs_version: '6'
 
 version: '{build}'

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "git://github.com/nfischer/shelljs-exec-proxy.git"
   },
   "dependencies": {
-    "shelljs": "^0.7.0"
+    "shelljs": "^0.8.4"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
This updates ShellJS from "^0.7.0" to "^0.8.4". This is necessary to
resolve issue #20 (the node 14 circular dependency warning).

This passes the automated tests. Off the top of my head, I can't
remember what breaking changes landed in v0.8.*, so I'm hoping this
should be safe.

This also updates appveyor and travis to test the node LTS releases
(even-numbered releases) from 6 through 14.