### PR TITLE
chore: remove codecov devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "test": "nyc --reporter=text --reporter=lcov mocha",
     "lint": "eslint .",
     "changelog": "shelljs-changelog",
-    "codecov": "codecov",
     "release:major": "shelljs-release major",
     "release:minor": "shelljs-release minor",
     "release:patch": "shelljs-release patch"
@@ -37,7 +36,6 @@
     "common.js"
   ],
   "devDependencies": {
-    "codecov": "^3.8.1",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.17.3",


### PR DESCRIPTION
No change to logic. This removes the codecov package dependency because
this is provided through GitHub Actions now.