### PR TITLE
chore: update CI to include v18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,7 @@ jobs:
           - 12
           - 14
           - 16
+          - 18
         os:
           - ubuntu-latest
           - macos-latest

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Nate Fischer <ntfschr@gmail.com> (https://github.com/nfischer)",
   "license": "MIT",
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=6"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
No change to logic. This updates GitHub actions to test up through node
v18.