### PR TITLE
test: increase timeouts more

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -19,7 +19,7 @@ function unix() {
 }
 
 describe('proxy', function describeproxy() {
-  this.timeout(5000); // shell.exec() is slow
+  this.timeout(10000); // shell.exec() is slow
   let delVarName;
 
   before(() => {


### PR DESCRIPTION
One of the tests timed out on Travis CI. Another test case was close to the timeout (4650ms). This doubles the timeout to make things more robust.