### PR TITLE
test: cleanup cross-platform behavior in tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,4 +66,12 @@ const proxyifyCmd = (t, ...cmdStart) => {
 // origShell.ShellString = ShellStringProxy;
 
 // export the modified shell
-module.exports = proxyifyCmd(origShell);
+const proxifiedShell = proxyifyCmd(origShell);
+
+// Allow access to native commands, bypassing ShellJS builtins. Useful for
+// testing, but most usecases should prefer calling the proxifiedShell directly
+// which prefers ShellJS builtins when available. Store this under an unusual
+// name to limit the risk of name conflicts with real commands.
+// eslint-disable-next-line no-underscore-dangle
+proxifiedShell.__native = proxyifyCmd({});
+module.exports = proxifiedShell;


### PR DESCRIPTION
This exposes `shell.__native`, which can be used to bypass ShellJS builtins and call native commands directly. e.g., `shell.__native.rm()` will call the native platform 'rm' binary. This should not be used for most usecases. I'm primarily creating this just for testing this module.

This refactors tests to use `shell.__native` where it improves readability and also adds some helpful assertions.