### PR TITLE
chore: drop old node versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 6
-          - 8
-          - 10
-          - 12
-          - 14
-          - 16
           - 18
           - 20
           - 22
@@ -23,17 +17,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        exclude:
-          - node-version: 6
-            os: macos-latest
-          - node-version: 8
-            os: macos-latest
-          - node-version: 10
-            os: macos-latest
-          - node-version: 12
-            os: macos-latest
-          - node-version: 14
-            os: macos-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2

--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
   ],
   "author": "Nate Fischer <ntfschr@gmail.com> (https://github.com/nfischer)",
   "license": "MIT",
-  "engines": {
-    "node": ">=6"
-  },
   "repository": {
     "type": "git",
     "url": "git://github.com/nfischer/shelljs-exec-proxy.git"
@@ -44,5 +41,8 @@
     "shelljs-changelog": "^0.2.6",
     "shelljs-release": "^0.5.2",
     "should": "^13.2.3"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
This drops support for node v6 up until v18.