### PR TITLE
docs: remove mention of node v6 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ shell.git.commit('-am', `I'm updating the "foo" module to be more secure`);
 
 ## Installation
 
-**Important:** This is only available for Node v6+ (it requires ES6 Proxies!)
-
 ```
 $ npm install --save shelljs-exec-proxy
 ```


### PR DESCRIPTION
We dropped node v6 support already so this line isn't relevant.