### PR TITLE
refactor: switch to shell.cmd()

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,9 @@ const proxyifyCmd = (t, ...cmdStart) => {
   t = t || function _t(...args) {
     // Wrap all the arguments in quotes
     const newArgs = cmdStart
-      .concat(args)
-      .map((x) => JSON.stringify(x));
+      .concat(args);
     // Run this command in the shell
-    return origShell.exec.call(this.stdout, newArgs.join(' '));
+    return origShell.cmd(...newArgs);
   };
   // Store the list of commands, in case we have a subcommand chain
   t[cmdArrayAttr] = cmdStart;


### PR DESCRIPTION
This swaps out shell.exec() in favor of shell.cmd(). This should offer more reliable performance and consistent behavior.

There's a known issue that this causes one test case to fail due to a change in behavior for globbing.